### PR TITLE
Fix the phantomjs dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,10 @@
     "haml": "~0.4.3",
     "less": "~1.7.0",
     "lodash": "~2.4.1",
-    "mocha-phantomjs": "^3.4.1",
     "ncp": "~0.5.1",
     "nib": "~1.0.2",
     "node-sass": "~0.8.4",
     "optimist": "~0.6.1",
-    "phantomjs": "^1.9.7-8",
     "promptly": "~0.2.0",
     "react-tools": "~0.13.0",
     "resolve": "git://github.com/orktes/node-resolve.git",
@@ -54,6 +52,8 @@
     "chai": "~1.9.1",
     "jsxcs": "0.0.2",
     "jsxhint": "^0.4.10",
-    "mocha": "~1.18.2"
+    "mocha": "~1.18.2",
+    "mocha-phantomjs": "~4.0.0",
+    "phantomjs": "~1.9.20"
   }
 }


### PR DESCRIPTION
PhantomJS and its mocha adapter are only used for testing, so they
belong in devDependencies.
Bumped the versions to phantomjs 1.9.20 and mocha-phantomjs 4.0.0